### PR TITLE
Modify setting messageSource basenames

### DIFF
--- a/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideMessageSourceConfiguration.java
+++ b/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideMessageSourceConfiguration.java
@@ -15,7 +15,7 @@ public class WallRideMessageSourceConfiguration extends MessageSourceAutoConfigu
 	@Override
 	public MessageSource messageSource() {
 		ResourceBundleMessageSource messageSource = (ResourceBundleMessageSource) super.messageSource();
-		messageSource.setBasenames(
+		messageSource.addBasenames(
 				"messages/messages",
 				"messages/validations",
 				"messages/enumerations",


### PR DESCRIPTION
Use addBasenames instead of setBasenames method for MessageSourceConfiguration so that additional message properties file can not be overridden