### PR TITLE
BUGFIX #109 for Article Cover Image that is not getting resized

### DIFF
--- a/wallride-core/src/main/java/org/wallride/web/support/MediaHttpRequestHandler.java
+++ b/wallride-core/src/main/java/org/wallride/web/support/MediaHttpRequestHandler.java
@@ -99,7 +99,7 @@ public class MediaHttpRequestHandler extends ResourceHttpRequestHandler implemen
 		Resource resized = resource;
 		boolean doResize = (width > 0 || height > 0);
 		if (doResize && "image".equals(MediaType.parseMediaType(media.getMimeType()).getType())) {
-			resized = prefix.createRelative(String.format("%s.resized/%dx%d-%d",
+			resized = prefix.createRelative(String.format("%s.resized.%dx%d-%d",
 					media.getId(),
 					width, height, mode.ordinal()));
 			if (!resized.exists() || resource.lastModified() > resized.lastModified()) {


### PR DESCRIPTION
Hello,

I created a bugfix that worked for me. 
Thinking the error is because auf the resized image is stored in a subfolder which can not always be created. I changed the code to store the resized image in the same directory.
Maybe this can be merged into the official repo?

br franz stumpner