### PR TITLE
Enhancement for multiple instances in one servlet engine

### DIFF
--- a/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideInitializer.java
+++ b/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideInitializer.java
@@ -38,7 +38,7 @@ public class WallRideInitializer implements ApplicationListener<ApplicationStart
 	 * @see ConfigFileApplicationListener#DEFAULT_SEARCH_LOCATIONS
 	 */
 	private static final String DEFAULT_CONFIG_SEARCH_LOCATIONS = "classpath:/,classpath:/config/,file:./,file:./config/,file:\\\\config\\\\";
-	private static final String FALLBACK_WALLRIDE_HOME = "file:/srv/wallride-home/";
+	private static final String FALLBACK_WALLRIDE_HOME = "/srv/wallride-home/";
 
 	@Override
 	public void onApplicationEvent(ApplicationStartingEvent event) {

--- a/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideInitializer.java
+++ b/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideInitializer.java
@@ -38,7 +38,7 @@ public class WallRideInitializer implements ApplicationListener<ApplicationStart
 	 * @see ConfigFileApplicationListener#DEFAULT_SEARCH_LOCATIONS
 	 */
 	private static final String DEFAULT_CONFIG_SEARCH_LOCATIONS = "classpath:/,classpath:/config/,file:./,file:./config/,file:\\\\config\\\\";
-	private static final String FALLBACK_WALLRIDE_HOME = "/srv/wallride-home/";
+	private static final String FALLBACK_WALLRIDE_HOME = "file:/srv/wallride-home/";
 
 	@Override
 	public void onApplicationEvent(ApplicationStartingEvent event) {

--- a/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideInitializer.java
+++ b/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideInitializer.java
@@ -37,8 +37,7 @@ public class WallRideInitializer implements ApplicationListener<ApplicationStart
 	/**
 	 * @see ConfigFileApplicationListener#DEFAULT_SEARCH_LOCATIONS
 	 */
-	private static final String DEFAULT_CONFIG_SEARCH_LOCATIONS = "classpath:/,classpath:/config/,file:./,file:./config/,file:\\\\config\\\\";
-	private static final String FALLBACK_WALLRIDE_HOME = "/srv/wallride-home/";
+	private static final String DEFAULT_CONFIG_SEARCH_LOCATIONS = "classpath:/,classpath:/config/,file:./,file:./config/";
 
 	@Override
 	public void onApplicationEvent(ApplicationStartingEvent event) {
@@ -51,15 +50,11 @@ public class WallRideInitializer implements ApplicationListener<ApplicationStart
 
 		String home = environment.getProperty(WallRideProperties.HOME_PROPERTY);
 		if (!StringUtils.hasText(home)) {
-			//if wallride.home is empty use fallback
-			System.out.println("wallride.home not set, using "+FALLBACK_WALLRIDE_HOME+" as fallback");
-			home = FALLBACK_WALLRIDE_HOME;
+			throw new IllegalStateException(WallRideProperties.HOME_PROPERTY + " is empty");
 		}
 		if (!home.endsWith("/")) {
 			home = home + "/";
 		}
-
-		System.out.println("Running Franz Stumpner Version of Wallride");
 
 		String config = home + WallRideProperties.DEFAULT_CONFIG_PATH_NAME;
 		String media = home + WallRideProperties.DEFAULT_MEDIA_PATH_NAME;

--- a/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideInitializer.java
+++ b/wallride-core/src/main/java/org/wallride/autoconfigure/WallRideInitializer.java
@@ -37,7 +37,8 @@ public class WallRideInitializer implements ApplicationListener<ApplicationStart
 	/**
 	 * @see ConfigFileApplicationListener#DEFAULT_SEARCH_LOCATIONS
 	 */
-	private static final String DEFAULT_CONFIG_SEARCH_LOCATIONS = "classpath:/,classpath:/config/,file:./,file:./config/";
+	private static final String DEFAULT_CONFIG_SEARCH_LOCATIONS = "classpath:/,classpath:/config/,file:./,file:./config/,file:\\\\config\\\\";
+	private static final String FALLBACK_WALLRIDE_HOME = "/srv/wallride-home/";
 
 	@Override
 	public void onApplicationEvent(ApplicationStartingEvent event) {
@@ -50,11 +51,15 @@ public class WallRideInitializer implements ApplicationListener<ApplicationStart
 
 		String home = environment.getProperty(WallRideProperties.HOME_PROPERTY);
 		if (!StringUtils.hasText(home)) {
-			throw new IllegalStateException(WallRideProperties.HOME_PROPERTY + " is empty");
+			//if wallride.home is empty use fallback
+			System.out.println("wallride.home not set, using "+FALLBACK_WALLRIDE_HOME+" as fallback");
+			home = FALLBACK_WALLRIDE_HOME;
 		}
 		if (!home.endsWith("/")) {
 			home = home + "/";
 		}
+
+		System.out.println("Running Franz Stumpner Version of Wallride");
 
 		String config = home + WallRideProperties.DEFAULT_CONFIG_PATH_NAME;
 		String media = home + WallRideProperties.DEFAULT_MEDIA_PATH_NAME;


### PR DESCRIPTION
To enable the operation of several wallride instances in one servlet engine (tomcat), there is now the possibility to configure the wallride.home parameter via a config file placed under the webroot directory.

**Example:**
If you deploy wallride as war to a tomcat to /srv/myblog.war you can place a config file to /srv/myblog.conf or /srv/wallride.conf with content:

`wallride.home=file:/srv/wallride-home/`

There is no need to config JAVA_OPTS for tomcat

**Multiple Instances:**

- For Instance 1 war-file may be placed to /srv/webapps/**myblog.war** 
 Place config file to /srv/webapps/**myblog.conf**

- For Instance 2 war-file my be placed to /srv/webapps/**yourblog.war**
 Place config file to /srv/webapps/**yourblog.conf**

I think this might be a really good enhancement.

Tested with Tomcat8

br franz stumpner