### PR TITLE
BUGFIX #112 context path is now considered when creating media

### DIFF
--- a/wallride-core/src/main/java/org/wallride/web/controller/admin/media/MediaCreateController.java
+++ b/wallride-core/src/main/java/org/wallride/web/controller/admin/media/MediaCreateController.java
@@ -27,6 +27,7 @@ import org.wallride.domain.Media;
 import org.wallride.service.MediaService;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 
 @Controller
 @RequestMapping("/{language}/media/create")
@@ -38,8 +39,8 @@ public class MediaCreateController {
 	private WallRideProperties wallRideProperties;
 
 	@RequestMapping(method=RequestMethod.POST)
-	public @ResponseBody MediaCreatedModel create(@RequestParam MultipartFile file) {
+	public @ResponseBody MediaCreatedModel create(@RequestParam MultipartFile file, HttpServletRequest request) {
 		Media media = mediaService.createMedia(file);
-		return new MediaCreatedModel(media, wallRideProperties);
+		return new MediaCreatedModel(media, request.getContextPath(), wallRideProperties);
 	}
 }

--- a/wallride-core/src/main/java/org/wallride/web/controller/admin/media/MediaCreatedModel.java
+++ b/wallride-core/src/main/java/org/wallride/web/controller/admin/media/MediaCreatedModel.java
@@ -29,9 +29,9 @@ public class MediaCreatedModel implements Serializable {
 
 	private String name;
 
-	public MediaCreatedModel(Media media, WallRideProperties wallRideProperties) {
+	public MediaCreatedModel(Media media, String contextPath, WallRideProperties wallRideProperties) {
 		this.id = media.getId();
-		this.link = wallRideProperties.getMediaUrlPrefix() + media.getId();
+		this.link = contextPath + wallRideProperties.getMediaUrlPrefix() + media.getId();
 		this.name = media.getOriginalName();
 	}
 


### PR DESCRIPTION
This is a fix when you run wallride under context path other than / (ROOT). For example www.example.com/myblog the link of the uploaded media (image) is now considering the path. Without this bugfix the media url is always /media/<filename> now when running under context path the media url is /<context>/media/<filename>